### PR TITLE
Add support for the CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(SpaceInvaders CXX)
+cmake_minimum_required(VERSION 3.10)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 17)
+
+set(SOURCES 
+    Source/Animation.cpp
+    Source/DrawText.cpp
+    Source/Enemy.cpp
+    Source/EnemyManager.cpp
+    Source/Main.cpp
+    Source/Player.cpp
+    Source/Ufo.cpp
+)
+
+set (HEADERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Headers/)
+
+find_package(SFML 2.5
+            COMPONENTS system window graphics audio REQUIRED)
+
+add_executable(invaders ${SOURCES})
+target_include_directories(invaders PRIVATE ${HEADERS_DIR} ${SFML_INCLUDE_DIRS})
+target_link_libraries(invaders sfml-graphics sfml-system sfml-audio ${SFML_DEPENDENCIES})
+
+# Copy resources to final executable location
+message(STATUS "Copying resource files to ${CMAKE_CURRENT_BINARY_DIR}")
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(SpaceInvaders CXX)
+ project(SpaceInvaders CXX)
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD 17)
@@ -22,6 +22,10 @@ add_executable(invaders ${SOURCES})
 target_include_directories(invaders PRIVATE ${HEADERS_DIR} ${SFML_INCLUDE_DIRS})
 target_link_libraries(invaders sfml-graphics sfml-system sfml-audio ${SFML_DEPENDENCIES})
 
-# Copy resources to final executable location
-message(STATUS "Copying resource files to ${CMAKE_CURRENT_BINARY_DIR}")
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+if(CMAKE_GENERATOR MATCHES "Visual Studio") 
+    add_custom_command(TARGET invaders POST_BUILD
+                       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/$<CONFIGURATION>/")
+else()
+    add_custom_command(TARGET invaders POST_BUILD
+                       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
- project(SpaceInvaders CXX)
+project(SpaceInvaders CXX)
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD 17)
@@ -24,8 +24,8 @@ target_link_libraries(invaders sfml-graphics sfml-system sfml-audio ${SFML_DEPEN
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio") 
     add_custom_command(TARGET invaders POST_BUILD
-                       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/$<CONFIGURATION>/")
+                       COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/$<CONFIGURATION>/Resources")
 else()
     add_custom_command(TARGET invaders POST_BUILD
-                       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/")
+                       COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/Source/Resources" "${CMAKE_BINARY_DIR}/Resources")
 endif()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Here's the video explaining how I did it: https://youtu.be/WfYNelQiQvc
         * *Debian/Ubuntu*: `sudo apt-get install libsfml-dev`
         * *Arch Linux and derivatives*: `sudo pacman -S sfml`
     2) Compile the project:
-    In the root folder:
+        
+        In the root folder:
         ```
         make build && cd build
         cmake ..

--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 Remake of the original Space Invaders game.
 
 Here's the video explaining how I did it: https://youtu.be/WfYNelQiQvc
+
+## Compile instructions
+* If you're using Visual Studio:
+    Visual studio can handle CMakeFiles automatically: see [this link](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170)
+* If you're on Linux:
+    1) Install SFML:
+
+        * *Debian/Ubuntu*: `sudo apt-get install libsfml-dev`
+        * *Arch Linux and derivatives*: `sudo pacman -S sfml`
+    2) Compile the project:
+    In the root folder:
+        ```
+        make build && cd build
+        cmake ..
+        make
+        ```
+    You should now have an executable file called `invaders` which you can run

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's the video explaining how I did it: https://youtu.be/WfYNelQiQvc
         
         In the root folder:
         ```
-        make build && cd build
+        mkdir build && cd build
         cmake ..
         make
         ```

--- a/Source/Headers/Global.hpp
+++ b/Source/Headers/Global.hpp
@@ -1,6 +1,8 @@
 //SO MANY CONSTANTS! AAAAAAAH!
 #pragma once
 
+#include <cmath>
+
 //I didn't wanna make PLAYER_SIZE, ENEMY_SIZE, BULLET_SIZE, so I just defined the base size.
 constexpr unsigned char BASE_SIZE = 16;
 constexpr unsigned char ENEMY_BULLET_SPEED = 2;


### PR DESCRIPTION
The current project is meant to be compiled on Visual Studio only.
By adding a CMakeLists.txt (and thus supporting the CMake build system), the project can now be compiled easily on all the platforms supported by CMake (including Visual Studio/Windows).